### PR TITLE
Don't error out if a version for a TsPermission is missing

### DIFF
--- a/app/controllers/timesheets_controller.rb
+++ b/app/controllers/timesheets_controller.rb
@@ -248,9 +248,9 @@ class TimesheetsController < ApplicationController
     # native versions assigned to user + shared versions visible in @ts_project
     # + versions associated to existing timelogs even if version no more visible to user
     # + versions associated to issues that are associated to some existing timelog
-    @active_orders = (TsPermission.for_user(@user).map(&:version).select{|x| x.in_timesheet == true} +
+    @active_orders = (TsPermission.for_user(@user).map(&:version).compact.select{|x| x.in_timesheet == true} +
         Project.find(@ts_project).shared_versions.visible(@user).where(:in_timesheet => true).all).uniq.sort_by{ |v| v.name.downcase}
-    @active_own_orders = (TsPermission.for_user(User.current).map(&:version).select{|x| x.in_timesheet == true} +
+    @active_own_orders = (TsPermission.for_user(User.current).map(&:version).compact.select{|x| x.in_timesheet == true} +
         Project.find(@ts_project).shared_versions.visible.where(:in_timesheet => true).all).uniq.sort_by{ |v| v.name.downcase}
     @orders = (@active_orders +
         Version.where(:id => TsTimeEntry.for_user(@user).map(&:order_id)).all +

--- a/lib/timesheets_app_project_patch.rb
+++ b/lib/timesheets_app_project_patch.rb
@@ -31,7 +31,7 @@ module TimesheetsAppProjectPatch
         @shared_versions = @shared_versions.where("(#{Version.table_name}.project_id = ? AND #{Version.table_name}.id IN (?))
                                                   OR (#{Version.table_name}.project_id != ? AND #{Version.table_name}.project_id IN (?))",
                                ts_project,
-                               TsPermission.where(:order_id => @shared_versions.all).for_user.map(&:version),
+                               TsPermission.where(:order_id => @shared_versions.all).for_user.map(&:version).compact,
                                ts_project,
                                Project.where(Project.allowed_to_condition(User.current, :view_issues)))
       end


### PR DESCRIPTION
Under conditions that are not yet fully clear to me, it can occur that there are TsPermission objects for a user whose version objects are missing. I think, this can occur if a version is simply deleted as the related TsPermission objects have no `:dependent => :destroy` relation. If that happens, the time sheet can not be displayed for users which have these invalid TsPermission objects in the database as it results in an exception when trying to access attributes of the version (which will be `nil` in this case).

This pull request doesn't remove the root-cause of the issue (as it is still a bit unclear, how this can happen) but it helps to handle the consequences: it just ignores `nil`-versions references from these TsPermission objects.