### PR TITLE
TsTimeEntry deletion and copy edge case

### DIFF
--- a/app/controllers/timesheets_controller.rb
+++ b/app/controllers/timesheets_controller.rb
@@ -140,15 +140,14 @@ class TimesheetsController < ApplicationController
       [entries]
     else
       entries = TsTimeEntry.for_user(@user).where("#{TsTimeEntry.table_name}.spent_on BETWEEN ? AND ?",@period_start,@period_end).where(:order_activity_id => params[:activity_id])
+      if !write_enabled(params[:order_id].to_i)
+        flash[:error] = l(:label_timesheet_missing_permission_on_order)
+        return []
+      end
       if params[:issue_id]
         entries = entries.where(:issue_id => params[:issue_id].to_i)
-      end
-      if params[:order_id]
-        if !write_enabled(params[:order_id].to_i)
-          flash[:error] = l(:label_timesheet_missing_permission_on_order)
-          return []
-        end
-        entries = entries.where(:order_id => params[:order_id])
+      else
+        entries = entries.where(:order_id => params[:order_id].to_i).where(:issue_id => nil)
       end
       entries.all
     end

--- a/lib/timesheets_app_project_patch.rb
+++ b/lib/timesheets_app_project_patch.rb
@@ -26,7 +26,7 @@ module TimesheetsAppProjectPatch
       noperm = @rolled_up_versions.select {|version| version.project_id == ts_proj && TsPermission.permission(User.current, version) == TsPermission::NONE }
       noallow = @rolled_up_versions.select {|version| version.project_id != ts_proj && !User.current.allowed_to?(:view_issues, version.project)}
       if Setting.plugin_redmine_app_timesheets["public_versions"].nil?
-        @rolled_up_versions = @rolled_up_versions.where("#{Version.table_name}.id NOT IN (?)", noperm + noallow + [""])
+        @rolled_up_versions = @rolled_up_versions.where.not(id: [noperm, noallow].flatten)
       end
       @rolled_up_versions
     end


### PR DESCRIPTION
Hi,

I've found and proposed a fix for a small edge case bug that I ran into last week. Here is the scenario:

1. A user creates a version and makes it an order called 'Version Order'.
2. The user creates an issue called 'Issue X' and selects 'Version Order'.
3. The user works on the issue and adds some time with an activity called 'Design'
4. The user adds the time entry to their timesheet
5. In the timesheet, the user selects 'Version Order' from the order selection
6. In the timesheet, the user selects 'Design' from the activity selection
7. In the timesheet, the user leaves the issue selection blank
8. In the timesheet, the user adds some time to this entry

Now the user has two lines in their timesheet:
Line 1 - has Version Order, Design, Issue X and some time
Line 2 - has Version Order, Design, (no issue) and some time.

The user may realise they've made a mistake or just want to change their mind so they select delete on Line 2. The result is that Line 1 and Line 2 are deleted at the same time.

This only happens when both lines have the same activity and order.

The pull request fixes this by ensuring that when params[:issue_id] is nil only orders where issue_id = nil are selected.

I also did some very minor refactoring but if I've messed up your flow then the only really important change is to add .where(:issue_id => nil) to the line where entries are selected based on order_id.

BTW, I've started thinking about what to put in the wiki, so I hopefully will get that done in the next month or so.

Adam